### PR TITLE
Update path to packages repo

### DIFF
--- a/opkg.conf
+++ b/opkg.conf
@@ -1,5 +1,5 @@
 src/gz base http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base
-src/gz snapshots http://downloads.openwrt.org/snapshots/trunk/x86_64/packages
+src/gz packages http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/packages
 dest root /
 dest ram /tmp
 lists_dir ext /var/opkg-lists


### PR DESCRIPTION
Update the correct path to packages uri and rename it from snapshots to packages.

This also fix the following annoying error:

```
Updated list of available packages in /var/opkg-lists/base.
Downloading http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/Packages.gz.
wget: server returned error: HTTP/1.1 404 Not Found
```
