### PR TITLE
Added functions.sh to support opkg-install https://dev.openwrt.org/brows...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Jeff Lindsay <progrium@gmail.com>
 ADD ./rootfs.tar /
 ADD ./opkg.conf         /etc/opkg.conf
 ADD ./opkg-install      /usr/bin/opkg-install
+ADD ./functions.sh      /lib/functions.sh
 RUN opkg-cl install http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base/libgcc_4.8-linaro-1_x86_64.ipk
 RUN opkg-cl install http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base/libc_0.9.33.2-1_x86_64.ipk
 

--- a/functions.sh
+++ b/functions.sh
@@ -1,0 +1,266 @@
+#!/bin/sh
+# Copyright (C) 2006-2013 OpenWrt.org
+# Copyright (C) 2006 Fokus Fraunhofer <carsten.tittel@fokus.fraunhofer.de>
+# Copyright (C) 2010 Vertical Communications
+debug () {
+        ${DEBUG:-:} "$@"
+}
+# newline
+N="
+"
+_C=0
+NO_EXPORT=1
+LOAD_STATE=1
+LIST_SEP=" "
+append() {
+        local var="$1"
+        local value="$2"
+        local sep="${3:- }"
+        eval "export ${NO_EXPORT:+-n} -- \"$var=\${$var:+\${$var}\${value:+\$sep}}\$value\""
+}
+list_contains() {
+        local var="$1"
+        local str="$2"
+        local val
+        eval "val=\" \${$var} \""
+        [ "${val%% $str *}" != "$val" ]
+}
+config_load() {
+        [ -n "$IPKG_INSTROOT" ] && return 0
+        uci_load "$@"
+}
+reset_cb() {
+        config_cb() { return 0; }
+        option_cb() { return 0; }
+        list_cb() { return 0; }
+}
+reset_cb
+package() {
+        return 0
+}
+config () {
+        local cfgtype="$1"
+        local name="$2"
+        export ${NO_EXPORT:+-n} CONFIG_NUM_SECTIONS=$(($CONFIG_NUM_SECTIONS + 1))
+        name="${name:-cfg$CONFIG_NUM_SECTIONS}"
+        append CONFIG_SECTIONS "$name"
+        [ -n "$NO_CALLBACK" ] || config_cb "$cfgtype" "$name"
+        export ${NO_EXPORT:+-n} CONFIG_SECTION="$name"
+        export ${NO_EXPORT:+-n} "CONFIG_${CONFIG_SECTION}_TYPE=$cfgtype"
+}
+option () {
+        local varname="$1"; shift
+        local value="$*"
+        export ${NO_EXPORT:+-n} "CONFIG_${CONFIG_SECTION}_${varname}=$value"
+        [ -n "$NO_CALLBACK" ] || option_cb "$varname" "$*"
+}
+list() {
+        local varname="$1"; shift
+        local value="$*"
+        local len
+        config_get len "$CONFIG_SECTION" "${varname}_LENGTH" 0
+        [ $len = 0 ] && append CONFIG_LIST_STATE "${CONFIG_SECTION}_${varname}"
+        len=$(($len + 1))
+        config_set "$CONFIG_SECTION" "${varname}_ITEM$len" "$value"
+        config_set "$CONFIG_SECTION" "${varname}_LENGTH" "$len"
+        append "CONFIG_${CONFIG_SECTION}_${varname}" "$value" "$LIST_SEP"
+        list_cb "$varname" "$*"
+}
+config_unset() {
+        config_set "$1" "$2" ""
+}
+# config_get <variable> <section> <option> [<default>]
+# config_get <section> <option>
+config_get() {
+        case "$3" in
+                "") eval echo "\${CONFIG_${1}_${2}:-\${4}}";;
+                *)  eval export ${NO_EXPORT:+-n} -- "${1}=\${CONFIG_${2}_${3}:-\${4}}";;
+        esac
+}
+# config_get_bool <variable> <section> <option> [<default>]
+config_get_bool() {
+        local _tmp
+        config_get _tmp "$2" "$3" "$4"
+        case "$_tmp" in
+                1|on|true|yes|enabled) _tmp=1;;
+                0|off|false|no|disabled) _tmp=0;;
+                *) _tmp="$4";;
+        esac
+        export ${NO_EXPORT:+-n} "$1=$_tmp"
+}
+config_set() {
+        local section="$1"
+        local option="$2"
+        local value="$3"
+        local old_section="$CONFIG_SECTION"
+        CONFIG_SECTION="$section"
+        option "$option" "$value"
+        CONFIG_SECTION="$old_section"
+}
+config_foreach() {
+        local ___function="$1"
+        [ "$#" -ge 1 ] && shift
+        local ___type="$1"
+        [ "$#" -ge 1 ] && shift
+        local section cfgtype
+        [ -z "$CONFIG_SECTIONS" ] && return 0
+        for section in ${CONFIG_SECTIONS}; do
+                config_get cfgtype "$section" TYPE
+                [ -n "$___type" -a "x$cfgtype" != "x$___type" ] && continue
+                eval "$___function \"\$section\" \"\$@\""
+        done
+}
+config_list_foreach() {
+        [ "$#" -ge 3 ] || return 0
+        local section="$1"; shift
+        local option="$1"; shift
+        local function="$1"; shift
+        local val
+        local len
+        local c=1
+        config_get len "${section}" "${option}_LENGTH"
+        [ -z "$len" ] && return 0
+        while [ $c -le "$len" ]; do
+                config_get val "${section}" "${option}_ITEM$c"
+                eval "$function \"\$val\" \"\$@\""
+                c="$(($c + 1))"
+        done
+}
+insert_modules() {
+        [ -d /etc/modules.d ] && {
+                cd /etc/modules.d
+                sed 's/^[^#]/insmod &/' $* | ash 2>&- || :
+        }
+}
+default_prerm() {
+        local name
+        name=$(echo $(basename $1) | cut -d. -f1)
+        [ -f /usr/lib/opkg/info/${name}.prerm-pkg ] && . /usr/lib/opkg/info/${name}.prerm-pkg
+        for i in `cat /usr/lib/opkg/info/${name}.list | grep "^/etc/init.d/"`; do
+                $i disable
+                $i stop
+        done
+}
+default_postinst() {
+        local name rusers
+        name=$(echo $(basename $1) | cut -d. -f1)
+        [ -f ${IPKG_INSTROOT}/usr/lib/opkg/info/${name}.postinst-pkg ] && ( . ${IPKG_INSTROOT}/usr/lib/opkg/info/${name}.postinst-pkg )
+        rusers=$(grep "Require-User:" ${IPKG_INSTROOT}/usr/lib/opkg/info/${name}.control)
+        [ -n "$rusers" ] && {
+                local user group uid gid
+                for a in $(echo $rusers | sed "s/Require-User://g"); do
+                        user=""
+                        group=""
+                        for b in $(echo $a | sed "s/:/ /g"); do
+                                local name id
+                                name=$(echo $b | cut -d= -f1)
+                                id=$(echo $b | cut -d= -f2)
+                                [ -z "$user" ] && {
+                                        user=$name
+                                        uid=$id
+                                        continue
+                                }
+                                gid=$id
+                                [ -n "$gid" ] && group_add $name $gid
+                                [ -z "$gid" ] && {
+                                        group_add_next $name
+                                        gid=$?
+                                }
+                                [ -z "$group" ] && {
+                                        user_exists $user || user_add $user "$uid" $gid
+                                        group=$name
+                                        continue
+                                }
+                                group_add_user $name $user
+                        done
+                done
+        }
+        [ "$PKG_UPGRADE" = "1" ] || for i in `cat ${IPKG_INSTROOT}/usr/lib/opkg/info/${name}.list | grep "^/etc/init.d/"`; do
+                [ -n "${IPKG_INSTROOT}" ] && $(which bash) ${IPKG_INSTROOT}/etc/rc.common ${IPKG_INSTROOT}$i enable; \
+                [ -n "${IPKG_INSTROOT}" ] || {
+                        $i enable
+                        $i start
+                }
+        done
+        return 0
+}
+include() {
+        local file
+        for file in $(ls $1/*.sh 2>/dev/null); do
+                . $file
+        done
+}
+find_mtd_index() {
+        local PART="$(grep "\"$1\"" /proc/mtd | awk -F: '{print $1}')"
+        local INDEX="${PART##mtd}"
+        echo ${INDEX}
+}
+find_mtd_part() {
+        local INDEX=$(find_mtd_index "$1")
+        local PREFIX=/dev/mtdblock
+        [ -d /dev/mtdblock ] && PREFIX=/dev/mtdblock/
+        echo "${INDEX:+$PREFIX$INDEX}"
+}
+group_add() {
+        local name="$1"
+        local gid="$2"
+        local rc
+        [ -f "${IPKG_INSTROOT}/etc/group" ] || return 1
+        [ -n "$IPKG_INSTROOT" ] || lock /var/lock/group
+        echo "${name}:x:${gid}:" >> ${IPKG_INSTROOT}/etc/group
+        rc=$?
+        [ -n "$IPKG_INSTROOT" ] || lock -u /var/lock/group
+        return $rc
+}
+group_exists() {
+        grep -qs "^${1}:" ${IPKG_INSTROOT}/etc/group
+}
+group_add_next() {
+        local gid gids
+        gid=$(grep -s "^${1}:" ${IPKG_INSTROOT}/etc/group | cut -d: -f3)
+        [ -n "$gid" ] && return $gid
+        gids=$(cat ${IPKG_INSTROOT}/etc/group | cut -d: -f3)
+        gid=100
+        while [ -n "$(echo $gids | grep $gid)" ] ; do
+                gid=$((gid + 1))
+        done
+        group_add $1 $gid
+        return $gid
+}
+group_add_user() {
+        local grp delim=","
+        grp=$(grep -s "^${1}:" ${IPKG_INSTROOT}/etc/group)
+        [ -z "$(echo $grp | cut -d: -f4 | grep $2)" ] || return
+        [ -n "$(echo $grp | grep ":$")" ] && delim=""
+        [ -n "$IPKG_INSTROOT" ] || lock /var/lock/passwd
+        sed -i "s/$grp/$grp$delim$2/g" ${IPKG_INSTROOT}/etc/group
+        [ -n "$IPKG_INSTROOT" ] || lock -u /var/lock/passwd
+}
+user_add() {
+        local name="${1}"
+        local uid="${2}"
+        local gid="${3}"
+        local desc="${4:-$1}"
+        local home="${5:-/var/run/$1}"
+        local shell="${6:-/bin/false}"
+        local rc
+        [ -z "$uid" ] && {
+                uids=$(cat ${IPKG_INSTROOT}/etc/passwd | cut -d: -f3)
+                uid=100
+                while [ -n "$(echo $uids | grep $uid)" ] ; do
+                        uid=$((uid + 1))
+                done
+        }
+        [ -z "$gid" ] && gid=$uid
+        [ -f "${IPKG_INSTROOT}/etc/passwd" ] || return 1
+        [ -n "$IPKG_INSTROOT" ] || lock /var/lock/passwd
+        echo "${name}:x:${uid}:${gid}:${desc}:${home}:${shell}" >> ${IPKG_INSTROOT}/etc/passwd
+        echo "${name}:x:0:0:99999:7:::" >> ${IPKG_INSTROOT}/etc/shadow
+        rc=$?
+        [ -n "$IPKG_INSTROOT" ] || lock -u /var/lock/passwd
+        return $rc
+}
+user_exists() {
+        grep -qs "^${1}:" ${IPKG_INSTROOT}/etc/passwd
+}
+[ -z "$IPKG_INSTROOT" -a -f /lib/config/uci.sh ] && . /lib/config/uci.sh


### PR DESCRIPTION
Jeff, I had a terrible time trying to get busybox/Dockerfile to run. Everytime I attempted to build it would error out with:

vagrant@dockerbuntu:~/busybox$ docker build .
Sending build context to Docker daemon  11.4 MB
Sending build context to Docker daemon
Step 0 : FROM       scratch
 ---> 511136ea3c5a
Step 1 : MAINTAINER Jeff Lindsay progrium@gmail.com
 ---> Using cache
 ---> f7c868d1d092
Step 2 : ADD ./rootfs.tar /
 ---> Using cache
 ---> 19fd31a41b13
Step 3 : ADD ./opkg.conf         /etc/opkg.conf
 ---> Using cache
 ---> b32f6f6626ab
Step 4 : ADD ./opkg-install      /usr/bin/opkg-install
 ---> Using cache
 ---> 04d9c0b14f20
Step 5 : RUN opkg-cl install http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base/libgcc_4.8-linaro-1_x86_64.ipk
 ---> Running in 16cdc12799cf
Downloading http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base/libgcc_4.8-linaro-1_x86_64.ipk.
Installing libgcc (4.8-linaro-1) to root...
//usr/lib/opkg/info/libgcc.postinst: .: line 3: can't open '/lib/functions.sh'
Configuring libgcc.
Collected errors:
- pkg_run_script: package "libgcc" postinst script returned status 2.
- opkg_configure: libgcc.postinst returned 2.
  2014/10/11 17:27:30 The command [/bin/sh -c opkg-cl install http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base/libgcc_4.8-linaro-1_x86_64.ipk] returned a non-zero code: 255

Turns out functions.sh (https://dev.openwrt.org/browser/trunk/package/base-files/files/lib/functions.sh) was missing, I'm not 100% sure why this file isn't included in opkg or if it's deliberate but using wget and putting into /lib solved the issue for me. 

Decided to add the file to the container. 

Thanks 
