### PR TITLE
Request to fix the URL for opkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD ./rootfs.tar /
 ADD ./opkg.conf         /etc/opkg.conf
 ADD ./opkg-install      /usr/bin/opkg-install
 ADD ./functions.sh      /lib/functions.sh
-RUN opkg-cl install http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base/libgcc_4.8-linaro-1_x86_64.ipk
-RUN opkg-cl install http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base/libc_0.9.33.2-1_x86_64.ipk
+RUN opkg-cl install http://downloads.openwrt.org/snapshots/trunk/x86_64/generic/packages/base/libgcc_4.8-linaro-1_x86_64.ipk
+RUN opkg-cl install http://downloads.openwrt.org/snapshots/trunk/x86_64/generic/packages/base/libc_0.9.33.2-1_x86_64.ipk
 
 CMD ["/bin/sh"]

--- a/opkg.conf
+++ b/opkg.conf
@@ -1,5 +1,5 @@
-src/gz base http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/base
-src/gz packages http://downloads.openwrt.org/snapshots/trunk/x86_64/packages/packages
+src/gz base http://downloads.openwrt.org/snapshots/trunk/x86_64/generic/packages/base
+src/gz packages http://downloads.openwrt.org/snapshots/trunk/x86_64/generic/packages/packages
 dest root /
 dest ram /tmp
 lists_dir ext /var/opkg-lists


### PR DESCRIPTION
Changed the URL in the Dockerfile so that libgcc installs.
Changed the URL in opkg.conf so that downstream opkg installs work again.
