### PR TITLE
Using the OpenWRT/LEDE snapshots (fixes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Notice:** *This image will probably soon be deprecated in favor of our even smaller [Alpine Linux based image](https://github.com/gliderlabs/docker-alpine). Alpine is a minimal Linux distro designed with containers in mind, based on Busybox, with a real, modern package system*
 
-This might not be the smallest Busybox container (4.8MB), but it has [opkg](http://wiki.openwrt.org/doc/techref/opkg), which means you can *very easily* install other [common packages](http://downloads.openwrt.org/snapshots/trunk/x86/64/packages/packages/) while keeping the image size to an absolute minimum.
+This might not be the smallest Busybox container (4.8MB), but it has [opkg](http://wiki.openwrt.org/doc/techref/opkg), which means you can *very easily* install other [common packages](http://downloads.lede-project.org/snapshots/packages/x86_64/) while keeping the image size to an absolute minimum.
 
 The convenience of `apt-get install` but for Busybox!
 
@@ -16,7 +16,7 @@ This image is meant to be used as the base image for Busybox-based containers. I
 
 The above Dockerfile grabs the latest package index during build, installs curl, bash, git, all their dependencies, and then deletes the local package index. **The result is a Docker image that's only 10MB.** Not too shabby.
 
-Compare that to a minimal Ubuntu 12.04 (which comes with curl, bash) after installing git: 300MB. 
+Compare that to a minimal Ubuntu 12.04 (which comes with curl, bash) after installing git: 300MB.
 
 ## Customizing buildroot configuration (Advanced)
 
@@ -30,7 +30,7 @@ This will run an interactive menu inside a Docker container to configure buildro
 	$ cd ..
 	$ make build
 
-This will cause buildroot to run again using [rootbuilder](https://github.com/progrium/rootbuilder) and your config. Building will likely take a while. The result will not only be a new `rootfs.tar`, but a new local Docker image tagged `busybox`. 
+This will cause buildroot to run again using [rootbuilder](https://github.com/progrium/rootbuilder) and your config. Building will likely take a while. The result will not only be a new `rootfs.tar`, but a new local Docker image tagged `busybox`.
 
 ## Sponsor
 

--- a/opkg.conf
+++ b/opkg.conf
@@ -1,8 +1,8 @@
-src/gz base http://downloads.openwrt.org/releases/packages-18.06/x86_64/base
-src/gz luci http://downloads.openwrt.org/releases/packages-18.06/x86_64/luci
-src/gz packages http://downloads.openwrt.org/releases/packages-18.06/x86_64/packages
-src/gz routing http://downloads.openwrt.org/releases/packages-18.06/x86_64/routing
-src/gz telephony http://downloads.openwrt.org/releases/packages-18.06/x86_64/telephony
+src/gz base http://downloads.lede-project.org/snapshots/packages/x86_64/base
+src/gz luci http://downloads.lede-project.org/snapshots/packages/x86_64/luci
+src/gz packages http://downloads.lede-project.org/snapshots/packages/x86_64/packages
+src/gz routing http://downloads.lede-project.org/snapshots/packages/x86_64/routing
+src/gz telephony http://downloads.lede-project.org/snapshots/packages/x86_64/telephony
 dest root /
 dest ram /tmp
 lists_dir ext /var/opkg-lists

--- a/opkg.conf
+++ b/opkg.conf
@@ -1,5 +1,8 @@
-src/gz base http://downloads.openwrt.org/snapshots/trunk/x86/64/packages/base
-src/gz packages http://downloads.openwrt.org/snapshots/trunk/x86/64/packages/packages
+src/gz base http://downloads.openwrt.org/releases/packages-18.06/x86_64/base
+src/gz luci http://downloads.openwrt.org/releases/packages-18.06/x86_64/luci
+src/gz packages http://downloads.openwrt.org/releases/packages-18.06/x86_64/packages
+src/gz routing http://downloads.openwrt.org/releases/packages-18.06/x86_64/routing
+src/gz telephony http://downloads.openwrt.org/releases/packages-18.06/x86_64/telephony
 dest root /
 dest ram /tmp
 lists_dir ext /var/opkg-lists


### PR DESCRIPTION
Provides a fix for #29 as the snapshot links don't seem to work any more => using the latest released ones.